### PR TITLE
 fixed log messages with rendered exception messages instead of templates

### DIFF
--- a/mech_vmware_dvs/driver.py
+++ b/mech_vmware_dvs/driver.py
@@ -83,7 +83,7 @@ class VMwareDVSMechanismDriver(driver_api.MechanismDriver):
                 exceptions.NotSupportedNetworkType) as e:
             LOG.info(_LI('Network %(id)s not created. Reason: %(reason)s') % {
                 'id': context.current['id'],
-                'reason': e.message})
+                'reason': six.text_type(e)})
         except exceptions.InvalidNetwork:
             pass
         else:
@@ -97,7 +97,7 @@ class VMwareDVSMechanismDriver(driver_api.MechanismDriver):
                 exceptions.NotSupportedNetworkType) as e:
             LOG.info(_LI('Network %(id)s not updated. Reason: %(reason)s') % {
                 'id': context.current['id'],
-                'reason': e.message})
+                'reason': six.text_type(e)})
         except exceptions.InvalidNetwork:
             pass
         else:
@@ -111,7 +111,7 @@ class VMwareDVSMechanismDriver(driver_api.MechanismDriver):
                 exceptions.NotSupportedNetworkType) as e:
             LOG.info(_LI('Network %(id)s not deleted. Reason: %(reason)s') % {
                 'id': context.current['id'],
-                'reason': e.message})
+                'reason': six.text_type(e)})
         except exceptions.InvalidNetwork:
             pass
         else:
@@ -131,7 +131,7 @@ class VMwareDVSMechanismDriver(driver_api.MechanismDriver):
         except exceptions.NotSupportedNetworkType as e:
             LOG.info(_LI('Port %(id)s not updated. Reason: %(reason)s') % {
                 'id': context.current['id'],
-                'reason': e.message})
+                'reason': six.text_type(e)})
         except exceptions.NoDVSForPhysicalNetwork:
             raise exceptions.InvalidSystemState(details=_(
                 'Port %(port_id)s belong to VMWare VM, but there is no '


### PR DESCRIPTION
Replaced this:

2015-11-09 11:03:01.267 392 INFO mech_vmware_dvs.driver [req-2d0aa085-c1dc-4cef-855e-4a4e6a1a5d42 ] Network 587490ca-2806-44a1-bc0b-37789ad366a7 not created. Reason: VMWare DVS driver don't support %(network_type)s network

with this:

2015-11-09 11:18:46.266 577 INFO mech_vmware_dvs.driver [req-a1169618-e914-4e68-8591-e961140c8fae ] Network 6f62ea9d-ec6c-4c9f-a33c-e11094fa4287 not created. Reason: VMWare DVS driver don't support local network
