### PR TITLE
Remove incorrect call of _update_sg_rules_for_ports

### DIFF
--- a/mech_vmware_dvs/agentDVS/vCenter_firewall.py
+++ b/mech_vmware_dvs/agentDVS/vCenter_firewall.py
@@ -68,10 +68,11 @@ class DVSFirewallDriver(firewall.FirewallDriver):
         return self.dvs_ports
 
     def update_security_group_rules(self, sg_id, sg_rules):
+        self._apply_ip_set(sg_rules)
         if sg_id in self.sg_rules and self.sg_rules[sg_id] == sg_rules:
             return
-        self._apply_ip_set(sg_rules)
         self.sg_rules[sg_id] = sg_rules
+        self._update_sg_rules_for_ports(set([sg_id]))
         LOG.debug("Update rules of security group (%s)", sg_id)
 
     def update_security_group_members(self, sg_id, sg_members):

--- a/mech_vmware_dvs/agentDVS/vCenter_firewall.py
+++ b/mech_vmware_dvs/agentDVS/vCenter_firewall.py
@@ -70,13 +70,8 @@ class DVSFirewallDriver(firewall.FirewallDriver):
     def update_security_group_rules(self, sg_id, sg_rules):
         if sg_id in self.sg_rules and self.sg_rules[sg_id] == sg_rules:
             return
-        elif sg_id in self.sg_rules:
-            # For remote sg rules we need to apply ip_sets manually
-            sg_rules = self._apply_ip_set(sg_rules)
-            if self.sg_rules[sg_id] == sg_rules:
-                return
+        self._apply_ip_set(sg_rules)
         self.sg_rules[sg_id] = sg_rules
-        self._update_sg_rules_for_ports([sg_id])
         LOG.debug("Update rules of security group (%s)", sg_id)
 
     def update_security_group_members(self, sg_id, sg_members):
@@ -91,9 +86,9 @@ class DVSFirewallDriver(firewall.FirewallDriver):
                         rule['ip_set'] = sg_members[ethertype]
                         updated = True
                         updated_sgs.add(sg)
+        self.sg_members[sg_id] = sg_members
         if updated:
             self._update_sg_rules_for_ports(updated_sgs)
-        self.sg_members[sg_id] = sg_members
         LOG.debug("Update members of security group (%s)", sg_id)
 
     def _apply_ip_set(self, rules):

--- a/mech_vmware_dvs/tests/test_vCenter_firewall.py
+++ b/mech_vmware_dvs/tests/test_vCenter_firewall.py
@@ -105,17 +105,9 @@ class TestDVSFirewallDriver(base.BaseTestCase):
 
     def test_update_security_group_rules(self):
         sg_rules = [FAKE_SG_RULE_IPV6, FAKE_SG_RULE_IPV4_PORT]
-        port = self._fake_port(
-            '1234', [FAKE_SG_RULE_IPV6])
-        self.firewall.dvs_ports = {port['device']: port}
-        self.firewall.dvs_port_map = {self.dvs: set([port['id']])}
-        with mock.patch.object(sg_utils, 'update_port_rules') as update_port:
-            self.firewall.update_security_group_rules('1234', sg_rules)
-            expected_port = port
-            expected_port['security_group_rules'] = sg_rules
-            update_port.assert_called_once_with(self.dvs, [expected_port])
-            self.assertEqual({'1234': sg_rules},
-                             self.firewall.sg_rules)
+        self.firewall.update_security_group_rules('1234', sg_rules)
+        self.assertEqual({'1234': sg_rules},
+                         self.firewall.sg_rules)
 
     def test_update_security_group_rules_no_action(self):
         sg_rules = [FAKE_SG_RULE_IPV6, FAKE_SG_RULE_IPV4_PORT]
@@ -126,16 +118,13 @@ class TestDVSFirewallDriver(base.BaseTestCase):
     def test_update_security_group_rules_apply_ip_set(self):
         self.firewall.sg_members = {'12345': {'IPv4': ['192.168.0.3'],
                                               'IPv6': []}}
-        with mock.patch.object(sg_utils, 'update_port_rules') as update_port:
-            updated_sg_rules = [FAKE_SG_RULE_IPV6, FAKE_SG_RULE_IPV4_PORT,
-                                FAKE_SG_RULE_IPV4_WITH_REMOTE]
-            self.firewall.update_security_group_rules(
-                '1234', updated_sg_rules)
-            self.port['security_group_rules'] = updated_sg_rules
-            update_port.assert_called_once_with(self.dvs, [self.port])
-            updated_sg_rules[2]['ip_set'] = ['192.168.0.3']
-            self.assertEqual({'1234': updated_sg_rules},
-                             self.firewall.sg_rules)
+        updated_sg_rules = [FAKE_SG_RULE_IPV6, FAKE_SG_RULE_IPV4_PORT,
+                            FAKE_SG_RULE_IPV4_WITH_REMOTE]
+        self.firewall.update_security_group_rules(
+            '1234', updated_sg_rules)
+        updated_sg_rules[2]['ip_set'] = ['192.168.0.3']
+        self.assertEqual({'1234': updated_sg_rules},
+                         self.firewall.sg_rules)
 
     def test_update_security_group_members(self):
         sg_members = {'IPv4': ['192.168.0.3'], 'IPv6': []}


### PR DESCRIPTION
update_security_group_rules and update_security_group_members
always called together, so remove _update_sg_rules_for_ports
from update_security_group_rules, as ip_set can be apllied
incorrectly at that moment.
