### PR TITLE
Create DVSSecurityGroupRpc

### DIFF
--- a/vmware_dvs/agent/dvs_neutron_agent.py
+++ b/vmware_dvs/agent/dvs_neutron_agent.py
@@ -35,6 +35,7 @@ from oslo_log import log as logging
 import oslo_messaging
 
 from vmware_dvs.utils import dvs_util
+from vmware_dvs.agent.firewalls import dvs_securitygroup_rpc as dvs_rpc
 
 LOG = logging.getLogger(__name__)
 cfg.CONF.import_group('AGENT', 'vmware_dvs.common.config')
@@ -74,7 +75,7 @@ class DVSNeutronAgent(sg_rpc.SecurityGroupAgentRpcCallbackMixin):
                 self._report_state)
             heartbeat.start(interval=report_interval)
         # Security group agent support
-        self.sg_agent = sg_rpc.SecurityGroupAgentRpc(self.context,
+        self.sg_agent = dvs_rpc.DVSSecurityGroupRpc(self.context,
                 self.sg_plugin_rpc, defer_refresh_firewall=True)
         self.iter_num = 0
         self.run_daemon_loop = True

--- a/vmware_dvs/agent/firewalls/dvs_securitygroup_rpc.py
+++ b/vmware_dvs/agent/firewalls/dvs_securitygroup_rpc.py
@@ -1,0 +1,39 @@
+# Copyright 2015 Mirantis, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+from oslo_log import log as logging
+
+from neutron.agent import securitygroups_rpc
+
+LOG = logging.getLogger(__name__)
+
+
+class DVSSecurityGroupRpc(securitygroups_rpc.SecurityGroupAgentRpc):
+
+    def _update_security_group_info(self, security_groups,
+                                    security_group_member_ips):
+        if security_group_member_ips and security_groups:
+            self.firewall.update_security_group_rules_and_members(
+                security_groups, security_group_member_ips)
+            LOG.debug("Update security group members and security group rules "
+                      "information")
+        elif security_groups:
+            for sg_id, sg_rules in security_groups.items():
+                self.firewall.update_security_group_rules(sg_id, sg_rules)
+            LOG.debug("Update security group information")
+        else:
+            for remote_sg_id, member_ips in security_group_member_ips.items():
+                self.firewall.update_security_group_members(
+                    remote_sg_id, member_ips)
+                LOG.debug("Update security group members information")

--- a/vmware_dvs/tests/unit/agent/test_vcenter_firewall.py
+++ b/vmware_dvs/tests/unit/agent/test_vcenter_firewall.py
@@ -150,6 +150,17 @@ class TestDVSFirewallDriver(base.BaseTestCase):
             self.assertEqual({self.port['device']: self.port},
                              self.firewall.dvs_ports)
 
+    def test_update_security_group_rules_and_members(self):
+        sg = {'1234': self.sg_rules}
+        sg_members = {'12345': {'IPv4': ['192.168.0.3'], 'IPv6': []}}
+        with mock.patch.object(sg_utils, 'update_port_rules') as update_port:
+            self.firewall.update_security_group_rules_and_members(sg,
+                                                                  sg_members)
+            update_port.assert_called_once_with(self.dvs, [self.port])
+            self.assertEqual(sg_members, self.firewall.sg_members)
+            self.port['security_group_rules'][1]['ip_set'] = ['192.168.0.3']
+            self.assertEqual(sg, self.firewall.sg_rules)
+
     def test__apply_sg_rules_for_port(self):
         self.firewall.sg_rules = {'1234': [FAKE_SG_RULE_IPV6,
                                            FAKE_SG_RULE_IPV4_PORT]}
@@ -162,10 +173,10 @@ class TestDVSFirewallDriver(base.BaseTestCase):
     def test__apply_ip_set(self):
         self.firewall.sg_members = {'1234': {'IPv4': ['192.168.0.3'],
                                              'IPv6': []}}
-        res_rules = self.firewall._apply_ip_set(self.sg_rules)
-        self.assertIn(FAKE_SG_RULE_IPV6, res_rules)
+        self.firewall._apply_ip_set(self.sg_rules)
+        self.assertIn(FAKE_SG_RULE_IPV6, self.sg_rules)
         FAKE_SG_RULE_IPV4_WITH_REMOTE.update({'ip_set': '192.168.0.3'})
-        self.assertIn(FAKE_SG_RULE_IPV4_WITH_REMOTE, res_rules)
+        self.assertIn(FAKE_SG_RULE_IPV4_WITH_REMOTE, self.sg_rules)
 
     def test__get_dvs_for_port_id(self):
         dvs = self.firewall._get_dvs_for_port_id(self.port['id'])

--- a/vmware_dvs/tests/unit/utils/test_util.py
+++ b/vmware_dvs/tests/unit/utils/test_util.py
@@ -140,7 +140,7 @@ class DVSControllerBaseTestCase(UtilBaseTestCase):
         self.dvs = mock.Mock()
 
         self.use_patch('vmware_dvs.utils.dvs_util.DVSController._get_dvs',
-                       return_value=self.dvs)
+                       return_value=(self.dvs, 'datacenter1'))
 
         self.controller = dvs_util.DVSController(self.dvs_name,
                                              self.connection)

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -60,7 +60,7 @@ class DVSController(object):
         self.connection = connection
         try:
             self.dvs_name = dvs_name
-            self._dvs = self._get_dvs(dvs_name, connection)
+            self._dvs, self.datacenter = self._get_dvs(dvs_name, connection)
         except vmware_exceptions.VimException as e:
             raise exceptions.wrap_wmvare_vim_exception(e)
 


### PR DESCRIPTION
Added firewall method update_security_group_rules_and_members.
When it will be needed to update both secutiry group rules and members
this method will be used instead of calling update_security_group_rules
and then update_security_group_members.
