### PR TITLE
The change of the driver building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+PBIN=/usr/bin
+PLIB=/usr/lib/python2.7/dist-packages/
+
+all: clean
+	fpm -s python -t deb --python-install-bin $(PBIN)  --python-install-lib $(PLIB) setup.py
+
+clean:
+	rm -rf *.deb

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,9 @@ setup-hooks =
 
 [entry_points]
 neutron.ml2.mechanism_drivers =
-    vmware_dvs = vmware_dvs.driver.dvs_mechanism_driver:VMwareDVSMechanismDriver
+    vmware_dvs = neutron.plugins.ml2.drivers.vmware_dvs.driver.dvs_mechanism_driver:VMwareDVSMechanismDriver
 console_scripts =
-    neutron-dvs-agent = vmware_dvs.agent.dvs_neutron_agent:main
+    neutron-dvs-agent = neutron.cmd.eventlet.plugins.dvs_neutron_agent:main
 
 [extract_messages]
 keywords = _ gettext ngettext l_ lazy_gettext


### PR DESCRIPTION
1. Add makefile to freezy few certain parameters of building.
2. Build the driver to be installed in /usr/bin and
   /usr/lib/python2.7/dist-packages/.
3. Change entry_points for new place of driver.
