### PR TITLE
rename tenant_name to project_name

### DIFF
--- a/vmware_dvs/utils/compute_util.py
+++ b/vmware_dvs/utils/compute_util.py
@@ -37,7 +37,7 @@ def _make_nova_client(cfg):
     params = dict(
         username=cfg.nova.username,
         api_key=cfg.nova.password,
-        project_id=cfg.nova.tenant_name,
+        project_id=cfg.nova.project_name,
         auth_url=cfg.nova.auth_url + "v2.0/",
     )
 


### PR DESCRIPTION
That option was renamed in neutron.conf. There is according changes
in the driver.
