### PR TITLE
Improve speed on port remove calls of DVS agent

### DIFF
--- a/vmware_dvs/common/config.py
+++ b/vmware_dvs/common/config.py
@@ -48,7 +48,7 @@ dvs_opts = [
                default=True,
                help=_("Run DVS cleaning procedure on agent restart.")),
     cfg.BoolOpt('precreate_networks',
-               default=True,
+               default=False,
                help=_("Precreate networks on DVS")),
 ]
 

--- a/vmware_dvs/common/constants.py
+++ b/vmware_dvs/common/constants.py
@@ -37,8 +37,6 @@ LOGIN_PROBLEM_TEXT = "Cannot complete login due to an incorrect "\
 DELETED_TEXT = "The object has already been deleted or has not been "\
                "completely created"
 
-INUSE_TEXT = 'is in use'
-
 DUPLICATE_NAME = "oslo_vmware.exceptions.DuplicateName"
 
 RESOURCE_IN_USE = "is in use."

--- a/vmware_dvs/common/constants.py
+++ b/vmware_dvs/common/constants.py
@@ -39,5 +39,7 @@ DELETED_TEXT = "The object has already been deleted or has not been "\
 
 DUPLICATE_NAME = "oslo_vmware.exceptions.DuplicateName"
 
+RESOURCE_IN_USE = "is in use."
+
 MIN_EPHEMERAL_PORT = 32768
 MAX_EPHEMERAL_PORT = 65535

--- a/vmware_dvs/common/constants.py
+++ b/vmware_dvs/common/constants.py
@@ -37,6 +37,8 @@ LOGIN_PROBLEM_TEXT = "Cannot complete login due to an incorrect "\
 DELETED_TEXT = "The object has already been deleted or has not been "\
                "completely created"
 
+INUSE_TEXT = 'is in use'
+
 DUPLICATE_NAME = "oslo_vmware.exceptions.DuplicateName"
 
 RESOURCE_IN_USE = "is in use."

--- a/vmware_dvs/common/exceptions.py
+++ b/vmware_dvs/common/exceptions.py
@@ -48,10 +48,6 @@ class DVSNotFound(ResourceNotFound):
     message = _('Distributed Virtual Switch %(dvs_name)s not found')
 
 
-class ResourceInUse(VMWareDVSException):
-    message = _('The resource %(resource)s is in use')
-
-
 class PortGroupNotFound(ResourceNotFound):
     message = _('Port Group %(pg_name)s not found')
 

--- a/vmware_dvs/tests/unit/driver/test_driver.py
+++ b/vmware_dvs/tests/unit/driver/test_driver.py
@@ -20,9 +20,11 @@ from neutron.tests import base
 
 from vmware_dvs.driver import dvs_mechanism_driver
 from vmware_dvs.common import constants as dvs_const, exceptions
+from vmware_dvs.common import config
 
 VALID_HYPERVISOR_TYPE = 'VMware vCenter Server'
 INVALID_HYPERVISOR_TYPE = '_invalid_hypervisor_'
+CONF = config.CONF
 
 
 class FAKE_SECURITY_GROUPS(object):
@@ -55,8 +57,9 @@ class VMwareDVSMechanismDriverTestCase(base.BaseTestCase):
         with mock.patch('vmware_dvs.api.dvs_agent_rpc_api.DVSClientAPI.'
                         'create_network_cast') as cast_mock:
             self.driver.create_network_precommit(context)
-            cast_mock.assert_called_once_with(
-                context.current, context.network_segments[0])
+            if CONF.DVS.precreate_networks:
+                cast_mock.assert_called_once_with(
+                    context.current, context.network_segments[0])
 
     def test_delete_network_postcommit_when_network_is_not_mapped(self):
         context = self._create_network_context()

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -54,6 +54,15 @@ class DVSController(object):
         except vmware_exceptions.VimException as e:
             raise exceptions.wrap_wmvare_vim_exception(e)
 
+    def check_free(self, key):
+        criteria = self.builder.port_criteria(port_key=key)
+        criteria.connected = True
+        connected_port_keys = set(
+            self.connection.invoke_api(self.connection.vim,
+                                       'FetchDVPortKeys',
+                                       self._dvs, criteria=criteria))
+        return not (key in connected_port_keys)
+
     def create_network(self, network, segment):
         name = self._get_net_name(network)
         blocked = not network['admin_state_up']

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -220,17 +220,18 @@ class DVSController(object):
             #setting.filterPolicy = self.builder.filter_policy([])
             #update_spec.setting = setting
             update_spec.operation = 'remove'
-            update_task = self.connection.invoke_api(
+            self.connection.invoke_api(
                 self.connection.vim, 'ReconfigureDVPort_Task',
                 self._dvs, port=[update_spec])
-            self.connection.wait_for_task(update_task)
+            #self.connection.wait_for_task(update_task)
             self.remove_block(port_info.key)
         except exceptions.PortNotFound:
             LOG.debug("Port %s was not found. Nothing to delete." % port['id'])
         except exceptions.ResourceInUse:
             LOG.debug("Port %s in use. Nothing to delete." % port['id'])
         except vmware_exceptions.VimException as e:
-            raise exceptions.wrap_wmvare_vim_exception(e)
+            LOG.error("No possible to remove %s." % str(e))
+            #raise exceptions.wrap_wmvare_vim_exception(e)
 
     def remove_block(self, port_key):
         self._blocked_ports.discard(port_key)

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -61,7 +61,7 @@ class DVSController(object):
             self.connection.invoke_api(self.connection.vim,
                                        'FetchDVPortKeys',
                                        self._dvs, criteria=criteria))
-        return not (key in connected_port_keys)
+        return key not in connected_port_keys
 
     def create_network(self, network, segment):
         name = self._get_net_name(network)
@@ -154,8 +154,8 @@ class DVSController(object):
                 if dvs_const.RESOURCE_IN_USE in e.message:
                     remove_used_pg_try += 1
                     if remove_used_pg_try > 3:
-                        LOG.info(_LI('Network %(name)s was not deleted. \
-                            Active ports were found') % {'name': name})
+                        LOG.info(_LI('Network %(name)s was not deleted. Active'
+                                     ' ports were found') % {'name': name})
                         break
                     else:
                         sleep(0.2)

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -151,7 +151,7 @@ class DVSController(object):
                 LOG.info(_LI('Network %(name)s deleted.') % {'name': name})
                 break
             except vmware_exceptions.VimException as e:
-                if dvs_const.INUSE_TEXT in e.message:
+                if dvs_const.RESOURCE_IN_USE in e.message:
                     remove_used_pg_try += 1
                     if remove_used_pg_try > 3:
                         LOG.info(_LI('Network %(name)s was not deleted. \

--- a/vmware_dvs/utils/dvs_util.py
+++ b/vmware_dvs/utils/dvs_util.py
@@ -508,11 +508,14 @@ class DVSControllerWithCache(DVSController):
         name = self._get_net_name(network)
         self._wait_port_group_stable_status(
             name, (READY_PG_STATUS, UPDATING_PG_STATUS))
-        if name in self._pg_cache:
+        if name in self._pg_cache and self._pg_cache[name]['item']:
             return self._pg_cache[name]['item']
 
-        self._pg_cache.setdefault(name, {}).update(
-            {'status': CREATING_PG_STATUS})
+        self._pg_cache.setdefault(name, {}).update({
+            'item': None,
+            'status': CREATING_PG_STATUS,
+            'pg_key': None
+        })
         try:
             pg = super(DVSControllerWithCache, self).create_network(
                 network, segment)
@@ -563,7 +566,7 @@ class DVSControllerWithCache(DVSController):
 
     def _increase_ports_on_portgroup(self, port_group):
         pg_name = next((name for name, pg in self._pg_cache.iteritems()
-                        if pg['pg_key'] == port_group.value), None)
+                        if pg.get('pg_key') == port_group.value), None)
         prev_status = self._pg_cache.get(pg_name, {}).get('status')
         self._wait_port_group_stable_status(pg_name)
         if prev_status == UPDATING_PG_STATUS:
@@ -587,7 +590,7 @@ class DVSControllerWithCache(DVSController):
 
     def _lookup_unbound_port(self, port_group):
         pg_name = next((name for name, pg in self._pg_cache.iteritems()
-                        if pg['pg_key'] == port_group.value), None)
+                        if pg.get('pg_key') == port_group.value), None)
         self._wait_port_group_stable_status(pg_name)
 
         if pg_name not in self._pg_cache:


### PR DESCRIPTION
Now we don't wait the result of vsphere port delete call. Port remove
procedure work faster if customer wants to remove many ports at
some time.
